### PR TITLE
Cleanup code

### DIFF
--- a/BenchmarkSample/benchmark/src/androidTest/AndroidManifest.xml
+++ b/BenchmarkSample/benchmark/src/androidTest/AndroidManifest.xml
@@ -17,7 +17,7 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="androidx.benchmark.test">
+    package="com.example.benchmark.test">
     <!-- Important: disable debuggable for accurate performance results -->
     <application
         android:debuggable="false"

--- a/BenchmarkSample/benchmark/src/androidTest/java/com/example/benchmark/AutoBoxingBenchmark.kt
+++ b/BenchmarkSample/benchmark/src/androidTest/java/com/example/benchmark/AutoBoxingBenchmark.kt
@@ -18,14 +18,14 @@ package com.example.benchmark
 
 import androidx.benchmark.BenchmarkRule
 import androidx.benchmark.measureRepeated
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
 @LargeTest
-@RunWith(JUnit4::class)
+@RunWith(AndroidJUnit4::class)
 class AutoBoxingBenchmark {
 
     @get:Rule

--- a/BenchmarkSample/benchmark/src/androidTest/java/com/example/benchmark/BitmapBenchmark.kt
+++ b/BenchmarkSample/benchmark/src/androidTest/java/com/example/benchmark/BitmapBenchmark.kt
@@ -20,18 +20,18 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import androidx.benchmark.BenchmarkRule
 import androidx.benchmark.measureRepeated
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
 private const val JETPACK = "images/jetpack.png"
 
 @LargeTest
-@RunWith(JUnit4::class)
+@RunWith(AndroidJUnit4::class)
 class BitmapBenchmark {
 
     @get:Rule

--- a/BenchmarkSample/benchmark/src/androidTest/java/com/example/benchmark/RecyclerViewBenchmark.kt
+++ b/BenchmarkSample/benchmark/src/androidTest/java/com/example/benchmark/RecyclerViewBenchmark.kt
@@ -7,6 +7,7 @@ import androidx.benchmark.measureRepeated
 import androidx.lifecycle.Lifecycle
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import com.example.benchmark.ui.MainActivity
 import org.junit.After
@@ -15,7 +16,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
 /**
  * RecyclerView benchmark - scrolls a RecyclerView, and measures the time taken to reveal each item
@@ -40,7 +40,7 @@ import org.junit.runners.JUnit4
  * - RenderThread and GPU Rendering work
  */
 @LargeTest
-@RunWith(JUnit4::class)
+@RunWith(AndroidJUnit4::class)
 class RecyclerViewBenchmark {
 
     @get:Rule
@@ -73,8 +73,7 @@ class RecyclerViewBenchmark {
     fun simpleScroll() {
         activityRule.scenario.onActivity {
             // If RecyclerView has children, the items are attached, bound, and gone through layout. Ready to benchmark.
-            assertTrue("RecyclerView expected to have children",
-                it.recyclerView.childCount > 0)
+            assertTrue("RecyclerView expected to have children", it.recyclerView.childCount > 0)
 
             benchmarkRule.measureRepeated {
                 // Scroll RecyclerView by one item

--- a/BenchmarkSample/benchmark/src/main/AndroidManifest.xml
+++ b/BenchmarkSample/benchmark/src/main/AndroidManifest.xml
@@ -14,4 +14,4 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<manifest package="androidx.benchmark"/>
+<manifest package="com.example.benchmark"/>


### PR DESCRIPTION
- Do not clash package names with benchmark lib itself
- AndroidJUnit4 over JUnit4 in instrumented tests